### PR TITLE
fix newlines in strings being removed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: julia:1.0                # image comes from Docker hub
+image: julia:1.6                # image comes from Docker hub
 
 before_script:
   - julia --project=@. -e "import Pkg; Pkg.build()"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
 #  - osx
 julia:
-  - 1.0
+  - 1.6
   - nightly
 notifications:
   email: false

--- a/src/IndentWrappers.jl
+++ b/src/IndentWrappers.jl
@@ -77,7 +77,7 @@ end
 function Base.write(iw::IndentWrapper, str::Union{SubString{String}, String})
     write_count = 0
     for (i, line) in enumerate(split(str, '\n'; keepempty = true))
-        i == 1 || (write_count += _write_spaces(iw))
+        i == 1 || (write_count += write(iw, '\n'))
         write_count += write(iw.parent, line)
     end
     write_count

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,14 @@ using IndentWrappers, Test
     @test buffer == expected
 end
 
+@testset "indent string" begin
+    io = IOBuffer()
+    print(indent(io, 4), "hello\nworld")
+    buffer = String(take!(io))
+    expected = "hello\n    world"
+    @test buffer == expected
+end
+
 @testset "write count" begin
     str = "a fish"
     io = indent(IOBuffer(), 8)


### PR DESCRIPTION
This was a general issue, but is more relevant now because Julia 1.6
introduced a change to println [1] and since then println did not work
with IndentWrapper and the tests broke.

I also updated CI to use Julia 1.6

[1] JuliaLang/julia@905ebec